### PR TITLE
Use id instead of _id

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -17,7 +17,7 @@ export default function XataAdapter(client, options = {}) {
       if (response.status > 299) {
         throw new Error(`Creating user in Xata: ${await response.text()}`);
       }
-      const { _id: userId } = await response.json();
+      const { id: userId } = await response.json();
       console.log(`createUser: created user with id ${userId}`);
       // returns AdapterUser
       return {
@@ -44,10 +44,10 @@ export default function XataAdapter(client, options = {}) {
       }
 
       const user = await response.json();
-      console.log("getUser: found user with id", user._id);
+      console.log("getUser: found user with id", user.id);
 
       return {
-        id: user._id,
+        id: user.id,
         name: user.name,
         email: user.email,
         emailVerified: null,
@@ -78,10 +78,10 @@ export default function XataAdapter(client, options = {}) {
       }
       const user = records[0];
 
-      console.log("getUserByEmail: found user with id", user._id);
+      console.log("getUserByEmail: found user with id", user.id);
 
       return {
-        id: user._id,
+        id: user.id,
         name: user.name,
         email: user.email,
         emailVerified: null,
@@ -121,10 +121,10 @@ export default function XataAdapter(client, options = {}) {
         );
       }
       const account = records[0];
-      console.log("getUserByAccount: returning user with id", account.user._id);
+      console.log("getUserByAccount: returning user with id", account.user.id);
 
       return {
-        id: account.user._id,
+        id: account.user.id,
         name: account.user.name,
         email: account.user.email,
         emailVerified: null,

--- a/components/ApplicationsList/index.js
+++ b/components/ApplicationsList/index.js
@@ -24,7 +24,7 @@ const ApplicationsList = () => {
   if (data.records.length == 0) {
     return (
       <Text mt={10} fontWeight={700}>
-        You didn&apos;t send any application for mentorship yet. Please, go to 
+        You didn&apos;t send any application for mentorship yet. Please, go to
         Find a mentor, and send your first one soon!
       </Text>
     );
@@ -33,7 +33,7 @@ const ApplicationsList = () => {
   return (
     <SimpleGrid mt={10} columns={1} spacing={10}>
       {data.records.map((application) => (
-        <ApplicationCard key={application._id} application={application} />
+        <ApplicationCard key={application.id} application={application} />
       ))}
     </SimpleGrid>
   );

--- a/components/MentorsList/MentorCard.js
+++ b/components/MentorsList/MentorCard.js
@@ -82,7 +82,7 @@ const MentorCard = ({ mentor, handleRequest }) => {
           justifyContent={"space-between"}
           alignItems={"center"}
         >
-          <NextLink href={`/mentors/${mentor._id}`}>
+          <NextLink href={`/mentors/${mentor.id}`}>
             <Button flex={1} colorScheme="grayButton">
               View
             </Button>

--- a/components/MentorsList/index.js
+++ b/components/MentorsList/index.js
@@ -64,7 +64,7 @@ const MentorsList = () => {
         <SimpleGrid minChildWidth="540px" spacing="24px">
           {filtered.map((mentor) => (
             <MentorCard
-              key={mentor._id}
+              key={mentor.id}
               mentor={mentor}
               handleRequest={handleRequestMentor}
             />

--- a/components/RequestModal/index.js
+++ b/components/RequestModal/index.js
@@ -34,7 +34,7 @@ const RequestModal = ({ mentor, isOpen, onClose }) => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        mentorId: mentor._id,
+        mentorId: mentor.id,
         message: data.message,
       }),
     });

--- a/components/RequestsList/index.js
+++ b/components/RequestsList/index.js
@@ -33,7 +33,7 @@ const RequestsList = () => {
   return (
     <SimpleGrid mt={10} columns={1} spacing={10}>
       {data.records.map((request) => (
-        <RequestCard key={request._id} request={request} />
+        <RequestCard key={request.id} request={request} />
       ))}
     </SimpleGrid>
   );

--- a/pages/api/applications.js
+++ b/pages/api/applications.js
@@ -34,7 +34,7 @@ async function handleGET(session, req, res) {
     body: JSON.stringify({
       columns: ["*", "mentor.*"],
       filter: {
-        mentee: user._id,
+        mentee: user.id,
       },
     }),
   });

--- a/pages/api/applicationsCount.js
+++ b/pages/api/applicationsCount.js
@@ -34,7 +34,7 @@ async function handleGET(session, req, res) {
     body: JSON.stringify({
       columns: ["*"],
       filter: {
-        mentee: user._id,
+        mentee: user.id,
       },
     }),
   });

--- a/pages/api/profile.js
+++ b/pages/api/profile.js
@@ -35,7 +35,7 @@ async function handlePUT(session, req, res) {
   const profile = req.body.profile;
 
   const data = await getByEmail(session.user.email);
-  const response = await fetch(`${DB_PATH}/tables/users/data/${data["_id"]}`, {
+  const response = await fetch(`${DB_PATH}/tables/users/data/${data["id"]}`, {
     method: "PUT",
     headers: {
       ...(await getXataHeaders()),

--- a/pages/api/request.js
+++ b/pages/api/request.js
@@ -29,7 +29,7 @@ async function handlePOST(session, req, res) {
 
   const reqObj = {
     mentor: req.body.mentorId,
-    mentee: user._id,
+    mentee: user.id,
     message: req.body.message,
   };
 

--- a/pages/api/requests.js
+++ b/pages/api/requests.js
@@ -34,7 +34,7 @@ async function handleGET(session, req, res) {
     body: JSON.stringify({
       columns: ["*", "mentee.*"],
       filter: {
-        mentor: user._id,
+        mentor: user.id,
       },
     }),
   });

--- a/pages/api/requestsCount.js
+++ b/pages/api/requestsCount.js
@@ -34,7 +34,7 @@ async function handleGET(session, req, res) {
     body: JSON.stringify({
       columns: ["*"],
       filter: {
-        mentor: user._id,
+        mentor: user.id,
       },
     }),
   });


### PR DESCRIPTION
There was a breaking change in xata where we replaced `_id` with just `id`, so this changes it everywhere in the Tupu app.

This fixes the issue where `View mentor` leads to an undefined ID and a broken page.

