### PR TITLE
Add a relationships table

### DIFF
--- a/xata/schema.yaml
+++ b/xata/schema.yaml
@@ -39,6 +39,21 @@ tables:
   - name: message
     type: text
 
+- name: relationships
+  columns:
+  - name: mentor
+    type: link
+    link:
+      table: users
+  - name: mentee
+    type: link
+    link:
+      table: users
+  - name: status
+    type: string
+  - name: startDate
+    type: string
+
 - name: nextauth_providers
   columns:
   - name: user


### PR DESCRIPTION
This adds a `relationships` table in which we can add an entry once a mentorship request is accepted. It contains links to the mentor and the mentee and some metadata (start date and status for now).
