### PR TITLE
Add status drop-down menu to RequestCard. Not correct size/responsive…

### DIFF
--- a/components/RequestsList/RequestCard.js
+++ b/components/RequestsList/RequestCard.js
@@ -81,7 +81,8 @@ const RequestCard = ({ request }) => {
           textAlign={"right"}
           justifyContent={"center"}
         >
-          <Select placeholder="Please choose a status" variant="filled" >
+          {/* set a label "status", make some status read-only */}
+          <Select placeholder="Pending" variant="filled" >
             <option value="option1">Mentorship started</option>
             <option value="option2">Mentorship finished</option>
             <option value="option3">Not a good fit</option>
@@ -98,6 +99,7 @@ const RequestCard = ({ request }) => {
         >
           <Button colorScheme={"greenButton"}>Accept</Button>
           <Button colorScheme={"grayButton"}>Reject</Button>
+          <Button colorScheme={"blueButton"}>Contact</Button>
         </Stack>
       </Stack>
     </Stack>

--- a/components/RequestsList/RequestCard.js
+++ b/components/RequestsList/RequestCard.js
@@ -1,6 +1,7 @@
 import { Avatar } from "@chakra-ui/avatar";
 import { Button } from "@chakra-ui/button";
 import { Heading, Link, Stack, Text } from "@chakra-ui/layout";
+import { Select } from '@chakra-ui/react'
 import ReactMarkdown from "react-markdown";
 import ChakraUIRenderer from "chakra-ui-markdown-renderer";
 import Icon from "@chakra-ui/icon";
@@ -73,6 +74,21 @@ const RequestCard = ({ request }) => {
           <ReactMarkdown components={ChakraUIRenderer(markdownTheme)} skipHtml>
             {request.message}
           </ReactMarkdown>
+        </Stack>
+
+        <Stack
+          direction={"column"}
+          textAlign={"right"}
+          justifyContent={"center"}
+        >
+          <Select placeholder="Please choose a status" variant="filled" >
+            <option value="option1">Mentorship started</option>
+            <option value="option2">Mentorship finished</option>
+            <option value="option3">Not a good fit</option>
+            <option value="option4">Request expired</option>
+            <option value="option5">Mentor busy</option>
+          </Select>
+
         </Stack>
 
         <Stack


### PR DESCRIPTION
… yet.

<!-- use WIP as prefix in the title if you do not want me to merge this, or set the PR status to Draft! -->

### What Github issue does this PR relate to?

Changes proposed in this pull request:

- [x] Add a dop-down menu to RequestCard for status selection

### What should the reviewer know?

I replaced "Pending" for now with "Please choose a status"

The size of the Select component is the same as the button and responsive as the buttons at the moment. Should be as large as the options text when width is the largest.
![issue27_select1](https://user-images.githubusercontent.com/79449522/162814257-3f81c685-d883-42bc-b648-4117ddccaecb.jpg)
![issue27_select2](https://user-images.githubusercontent.com/79449522/162814271-e4532409-1fe2-4344-8261-a2e6a8c5b9de.jpg)

### Quality Assurance(QA) Checklist

- [x] The app builds and runs properly
