### PR TITLE
WIP Mentor Preferences edit/view page

### DIFF
--- a/components/MentorPreferencesForm/editor.js
+++ b/components/MentorPreferencesForm/editor.js
@@ -1,0 +1,120 @@
+import { Button } from "@chakra-ui/button";
+import {
+  FormControl,
+  FormHelperText,
+  FormErrorMessage,
+  FormLabel,
+} from "@chakra-ui/form-control";
+import { Input } from "@chakra-ui/input";
+import { Flex, HStack, VStack } from "@chakra-ui/layout";
+import { useForm } from "react-hook-form";
+import { Switch, Link } from '@chakra-ui/react'
+import { ExternalLinkIcon } from '@chakra-ui/icons'
+
+export const MentorPreferencesEditor = ({ profile, setEditMode, mutateProfile }) => {
+  const { register, handleSubmit, formState: { errors } } = useForm({
+    mode: "all",
+    defaultValues: profile,
+  });
+
+  const onSubmit = async (data) => {
+    await fetch("/api/profile", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ profile: data }),
+    });
+    mutateProfile(data);
+    setEditMode(false);
+  };
+
+  const handleCancelClick = () => {
+    setEditMode(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Flex py={10}>
+        <VStack w="full" h="full" p={10} spacing={10} alignItems="flex-start">
+          <FormControl isInvalid={errors.mentor?.calendly}>
+            <FormLabel htmlFor="mentor.calendly">Calendly Event Link</FormLabel>
+            <Input
+              placeholder="https://calendly.com/your_username/your_event_name"
+              {...register("mentor.calendly", 
+                { required: { value: true, message: "Your Calendly event link is required to be able to start with mentoring."},
+                  pattern: {
+                    value: /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i,
+                    message: "Invalid URL link."
+                  } 
+                })}
+              id="mentor.calendly"
+            />
+            {errors.mentor?.calendly && 
+              <FormErrorMessage>{errors.mentor.calendly.message}</FormErrorMessage>
+            }            
+            <FormHelperText>
+              Your Calendly event link will be used by your mentees to book your mentorship sessions. Pick yours from your <Link href="https://calendly.com/event_types/user/me" isExternal>
+              Calendly events <ExternalLinkIcon mx='2px' />
+              </Link>.
+            </FormHelperText>
+          </FormControl>
+          <FormControl>
+            <FormLabel htmlFor="mentor.shortterm">Short term mentorships?</FormLabel>
+            <Switch
+              {...register("mentor.shortterm")}
+              id="mentor.shortterm"         
+            />
+            <FormHelperText>
+              Are you available for short term mentorship sessions (e.g. a one time call)?
+            </FormHelperText>
+          </FormControl>
+          <FormControl>
+            <FormLabel htmlFor="mentor.longterm">Long term mentorships?</FormLabel>
+            <Switch
+              {...register("mentor.longterm")}
+              id="mentor.longterm"         
+            />
+            <FormHelperText>
+              Would you be available for at least one long term mentorship relationship?
+            </FormHelperText>
+          </FormControl>
+          <FormControl>
+            <FormLabel htmlFor="mentor.notifications">Receive expiring mentorship request notifications?</FormLabel>
+            <Switch
+              {...register("mentor.notifications")}
+              id="mentor.notifications"         
+            />
+            <FormHelperText>
+            A mentorship request expires in 7 days if not addressed. Would you like to receive a notification per email 48 hours before a mentorship request expires?
+            </FormHelperText>
+          </FormControl>
+          <FormControl>
+            <FormLabel htmlFor="mentor.incognito">Incognito Mode</FormLabel>
+            <Switch
+              {...register("mentor.incognito")}
+              id="mentor.incognito"         
+            />
+            <FormHelperText>
+            Your profile as mentor will be shown only to logged-in users.
+            </FormHelperText>
+          </FormControl>
+          <FormControl>
+            <HStack spacing="24px">
+              <Button colorScheme="greenButton" size="md" type="submit">
+                Save
+              </Button>
+              <Button
+                onClick={handleCancelClick}
+                colorScheme="grayButton"
+                size="md"
+              >
+                Cancel
+              </Button>
+            </HStack>
+          </FormControl>
+        </VStack>
+      </Flex>
+    </form>
+  );
+};

--- a/components/MentorPreferencesForm/index.js
+++ b/components/MentorPreferencesForm/index.js
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { MentorPreferencesEditor } from "./editor";
+import { MentorPreferencesViewer } from "./viewer";
+import useSWR from "swr";
+import { Alert, AlertIcon } from "@chakra-ui/alert";
+
+const fetcher = (...args) => fetch(...args).then((res) => res.json());
+
+const MentorPreferencesForm = ({}) => {
+  const { data, error, mutate } = useSWR("/api/profile", fetcher);
+  const [editMode, setEditMode] = useState(false);
+
+  if (error) {
+    return (
+      <Alert status="error">
+        <AlertIcon />
+        Error getting data: {error}
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return <div>Loading..</div>;
+  }
+
+  if (editMode) {
+    return (
+      <MentorPreferencesEditor
+        profile={data}
+        setEditMode={setEditMode}
+        mutateProfile={mutate}
+      />
+    );
+  } else {
+    return <MentorPreferencesViewer profile={data} setEditMode={setEditMode} />;
+  }
+};
+
+export default MentorPreferencesForm;

--- a/components/MentorPreferencesForm/viewer.js
+++ b/components/MentorPreferencesForm/viewer.js
@@ -1,0 +1,53 @@
+import { Button } from "@chakra-ui/button";
+import { Flex, Text, VStack } from "@chakra-ui/layout";
+import { Table, Tbody, Td, Tr } from "@chakra-ui/table";
+import {
+  Alert,
+  AlertIcon,
+} from '@chakra-ui/react'
+
+export const MentorPreferencesViewer = ({ profile, setEditMode }) => {
+  const handleEditClick = (ev) => {
+    setEditMode(true);
+  };
+  return (
+    <Flex py={10} px={10}>
+      <VStack>
+      {!profile.mentor || !profile.mentor.calendly ? (
+        <Alert status='warning'>
+          <AlertIcon />
+          You preferences are not filled yet! Please edit your preferences to start with your mentoring journey.
+        </Alert>        
+      ) :  (        
+        <Table variant="simple" size="lg">
+          <Tbody>
+            <Tr>
+              <Td fontWeight={700}>Calendly Event Link</Td>
+              <Td minWidth={400}>{profile.mentor.calendly}</Td>
+            </Tr>
+            <Tr>
+              <Td fontWeight={700}>Short term mentorships</Td>
+              <Td>{profile.mentor.shortterm ? "Yes" : "No"}</Td>
+            </Tr>
+            <Tr>
+              <Td fontWeight={700}>Long term mentorships</Td>
+              <Td>{profile.mentor.longterm ? "Yes" : "No"}</Td>
+            </Tr>
+            <Tr>
+              <Td fontWeight={700}>Receive expiring mentorship request notifications</Td>
+              <Td>{profile.mentor.notifications ? "Yes" : "No"}</Td>
+            </Tr>
+            <Tr>
+              <Td fontWeight={700}>Incognito Mode</Td>
+              <Td>{profile.mentor.incognito ? "Active" : "Not Active"}</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+        )}
+        <Button onClick={handleEditClick} colorScheme="greenButton" size="md">
+          Edit Preferences
+        </Button>
+      </VStack>
+    </Flex>
+  );
+};

--- a/components/Sidebar/SidebarContent.js
+++ b/components/Sidebar/SidebarContent.js
@@ -7,6 +7,7 @@ import {
   FiInbox,
   FiSearch,
   FiSettings,
+  FiSliders,
   FiUser,
   FiUsers,
 } from "react-icons/fi";
@@ -23,6 +24,7 @@ const SidebarContent = ({ onClose, mode, ...rest }) => {
   const MentorLinkItems = [
     { name: "Home", icon: FiHome, href: "/" },
     { name: "Your profile", icon: FiUser, href: "/profile" },
+    { name: "Preferences", icon: FiSliders, href: "/preferences" },
     {
       name: "Requests",
       icon: FiInbox,

--- a/pages/api/profile.js
+++ b/pages/api/profile.js
@@ -52,6 +52,11 @@ async function handlePUT(session, req, res) {
       mentor: {
         status: data.mentor?.status,
         hide: data.mentor?.hide,
+        calendly: data.mentor?.calendly,
+        longterm: data.mentor?.longterm,
+        shortterm: data.mentor?.shortterm,
+        notifications: data.mentor?.notifications,
+        incognito: data.mentor?.incognito,
       },
     }),
   });

--- a/pages/preferences.js
+++ b/pages/preferences.js
@@ -1,0 +1,14 @@
+import { useState } from "react";
+import { Box, Heading } from "@chakra-ui/layout";
+import MentorPreferencesForm from "../components/MentorPreferencesForm";
+
+export default function PreferencesPage() {
+  return (
+    <>
+      <Heading mb={10}>Preferences</Heading>
+      <Box maxWidth="4xl" borderWidth="1px" borderRadius="lg" bg="white">
+        <MentorPreferencesForm />
+      </Box>
+    </>
+  );
+}

--- a/xata/schema.yaml
+++ b/xata/schema.yaml
@@ -1,66 +1,76 @@
-formatVersion: '1.0'
+formatVersion: "1.0"
 tables:
-- name: users
-  columns:
-  - name: name
-    type: string
-  - name: email
-    type: email
-  - name: title
-    type: string
-  - name: twitter
-    type: string
-  - name: linkedin
-    type: string
-  - name: biography
-    type: text
-  - name: picture
-    type: string
-  - name: roles
-    type: multiple
-  - name: mentor
-    type: object
+  - name: users
     columns:
-    - name: status
-      type: string
-    - name: hide
-      type: bool
-      
-- name: requests
-  columns:
-  - name: mentor
-    type: link
-    link:
-      table: users
-  - name: mentee
-    type: link
-    link:
-      table: users
-  - name: message
-    type: text
+      - name: name
+        type: string
+      - name: email
+        type: email
+      - name: title
+        type: string
+      - name: twitter
+        type: string
+      - name: linkedin
+        type: string
+      - name: biography
+        type: text
+      - name: picture
+        type: string
+      - name: roles
+        type: multiple
+      - name: mentor
+        type: object
+        columns:
+          - name: status
+            type: string
+          - name: hide
+            type: bool
+          - name: incognito
+            type: bool
+          - name: shortterm
+            type: bool
+          - name: longterm
+            type: bool
+          - name: notifications
+            type: bool
+          - name: calendly
+            type: string
 
-- name: relationships
-  columns:
-  - name: mentor
-    type: link
-    link:
-      table: users
-  - name: mentee
-    type: link
-    link:
-      table: users
-  - name: status
-    type: string
-  - name: startDate
-    type: string
+  - name: requests
+    columns:
+      - name: mentor
+        type: link
+        link:
+          table: users
+      - name: mentee
+        type: link
+        link:
+          table: users
+      - name: message
+        type: text
 
-- name: nextauth_providers
-  columns:
-  - name: user
-    type: link
-    link:
-      table: users
-  - name: provider
-    type: string
-  - name: providerAccountId
-    type: string
+  - name: relationships
+    columns:
+      - name: mentor
+        type: link
+        link:
+          table: users
+      - name: mentee
+        type: link
+        link:
+          table: users
+      - name: status
+        type: string
+      - name: startDate
+        type: string
+
+  - name: nextauth_providers
+    columns:
+      - name: user
+        type: link
+        link:
+          table: users
+      - name: provider
+        type: string
+      - name: providerAccountId
+        type: string


### PR DESCRIPTION
### What Github issue does this PR relate to?

Close #34

Changes proposed in this pull request:

- add menu entry for mentor: Preferences
- add Preferences page edit/view
- [ ] save to Xata

### What should the reviewer know?

**NB** on local dev, it seems not to store the information, although it seems that `handlePUT` receives it. I will test it on the preview.

The `yaml` file is formatted differently from yours, sorry about that: do you use any other setting / extension for it?

### Screencast

![mentor-preferences](https://user-images.githubusercontent.com/6698585/167715044-c53dbbb7-3771-4d9f-ad43-76968cbde3be.gif)


### Quality Assurance(QA) Checklist

- [x] The app builds and runs properly
