### PR TITLE
add `mode` in SidebarContent in DrawerContent #45

### DIFF
--- a/components/Sidebar/index.js
+++ b/components/Sidebar/index.js
@@ -41,7 +41,7 @@ export default function SidebarWithHeader({ mode, setMode, children }) {
         size="full"
       >
         <DrawerContent>
-          <SidebarContent onClose={onClose} />
+          <SidebarContent mode={mode} onClose={onClose} />
         </DrawerContent>
       </Drawer>
       <MobileNav


### PR DESCRIPTION
### What Github issue does this PR relate to?

Close #45

Changes proposed in this pull request:

- add `mode` in `SidebarContent` in `DrawerContent`

### What should the reviewer know?

Test the drawer of the `SidebarContent`

![mentor-sidebar-switch](https://user-images.githubusercontent.com/6698585/167727624-b5b97691-aa7b-4e87-9f54-aea216975746.gif)


### Quality Assurance(QA) Checklist

- [x] The app builds and runs properly
