### PR TITLE
Email notifications txt templates and JS utils functions

### DIFF
--- a/pages/api/testNotifications.js
+++ b/pages/api/testNotifications.js
@@ -7,6 +7,7 @@ import {
   sendMentorContactMenteeEmail,
   sendMentorMentorshipClosedEmail,
   sendMentorshipRequestAcceptedEmail,
+  sendMentorshipRequestCancelledEmail,
   sendMentorshipRequestRejectedEmail
 } from "../../utils/email";
 import { RequestStatusEnum } from "../../types/dbTablesEnums";
@@ -64,7 +65,7 @@ async function handleGET(session, req, res) {
     // });
 
     // sendMentorshipRequestAcceptedEmail({ mentee, mentor, longTerm: false });
-
+    // sendMentorshipRequestCancelledEmail({ mentee, mentor, longTerm: false });
     // sendMentorshipRequestRejectedEmail({ mentee, mentor, longTerm: true, requestStatus: RequestStatusEnum.Rejected });
     // sendMentorshipRequestRejectedEmail({ mentee, mentor, longTerm: true, requestStatus: RequestStatusEnum.RejectedBusy });
     // sendMentorshipRequestRejectedEmail({ mentee, mentor, longTerm: false, requestStatus: RequestStatusEnum.RejectedNoGoodFit });

--- a/pages/api/testNotifications.js
+++ b/pages/api/testNotifications.js
@@ -2,8 +2,14 @@ import { getSession } from "next-auth/react";
 import { getXataHeaders, DB_PATH } from "../../services";
 import { 
   sendPreferencesUpdatedEmail,
-  sendMentorshipRequestedEmail
+  sendMentorshipRequestedEmail,
+  sendMenteeMentorshipClosedEmail,
+  sendMentorContactMenteeEmail,
+  sendMentorMentorshipClosedEmail,
+  sendMentorshipRequestAcceptedEmail,
+  sendMentorshipRequestRejectedEmail
 } from "../../utils/email";
+import { RequestStatusEnum } from "../../types/dbTablesEnums";
 
 async function getByEmail(email) {
   const resp = await fetch(`${DB_PATH}/tables/users/query`, {
@@ -34,15 +40,42 @@ async function handleGET(session, req, res) {
   }
 
   if (process.env.DEV_EMAIL_RECIPIENT) {
+    
+    // careful, the free quota is 100/day
     sendPreferencesUpdatedEmail(profile.email, "Lorenzo")
 
-    const mentorshipRequest = { 
-      mentee: { name: "Mentee", email: "lorepirri+mentee@gmail.com" }, 
-      mentor: { name: "Mentor", email: "lorepirri+mentor@gmail.com" }, 
-      messageRequest: "Hi! I would like to talk to you!", 
-      longTerm: true
-    };  
-    sendMentorshipRequestedEmail(mentorshipRequest);
+    const mentee = { name: "Mentee", email: process.env.DEV_EMAIL_RECIPIENT };
+    const mentor = { name: "Mentor", email: process.env.DEV_EMAIL_RECIPIENT };
+
+    // sendMenteeMentorshipClosedEmail({ 
+    //   mentee, 
+    //   mentor, 
+    //   menteeFeedback: "the mentee feedback!", 
+    //   tupuFeedback: "the feedback for tupu" 
+    // });
+
+    // sendMentorContactMenteeEmail({ mentee, mentor, mentorMessage: "this is a message for you mentee!" });
+    
+    // sendMentorMentorshipClosedEmail({ 
+    //   mentee, 
+    //   mentor, 
+    //   mentorFeedback: "the mentor feedback!", 
+    //   tupuFeedback: "the feedback for tupu" 
+    // });
+
+    // sendMentorshipRequestAcceptedEmail({ mentee, mentor, longTerm: false });
+
+    // sendMentorshipRequestRejectedEmail({ mentee, mentor, longTerm: true, requestStatus: RequestStatusEnum.Rejected });
+    // sendMentorshipRequestRejectedEmail({ mentee, mentor, longTerm: true, requestStatus: RequestStatusEnum.RejectedBusy });
+    // sendMentorshipRequestRejectedEmail({ mentee, mentor, longTerm: false, requestStatus: RequestStatusEnum.RejectedNoGoodFit });
+
+    // const mentorshipRequest = { 
+    //   mentee,
+    //   mentor,
+    //   messageRequest: "Hi! I would like to talk to you!", 
+    //   longTerm: true
+    // };  
+    // sendMentorshipRequestedEmail(mentorshipRequest);
   }
 
   res.status(200).json(profile);

--- a/utils/email/index.js
+++ b/utils/email/index.js
@@ -206,6 +206,22 @@ export const sendMentorshipRequestAcceptedEmail = ({ mentee, mentor, longTerm })
   sendNotificationEmailToUsers(params);
 }
 
+export const sendMentorshipRequestCancelledEmail = ({ mentee, mentor, longTerm }) => {
+  // mentee and mentor = { name: "", email: "" }
+  const params = {
+    mentee, 
+    mentor,
+    templateName: 'mentorship-request-cancelled-email',
+    subject: "Mentorship request cancelled!",
+    fillInFieldsFn: (txtTemplate) => {
+      return txtTemplate
+        .replace(/\[\[menteeName\]\]/g, mentee.name)
+        .replace(/\[\[mentorName\]\]/g, mentor.name)
+        .replace(/\[\[longOrShortTerm\]\]/g, buildLongOrShortTermLabel(longTerm));
+    }
+  };
+  sendNotificationEmailToUsers(params);
+}
 export const sendMentorshipRequestRejectedEmail = ({ mentee, mentor, longTerm, requestStatus }) => {
   // mentee and mentor = { name: "", email: "" }
   const params = {

--- a/utils/email/index.js
+++ b/utils/email/index.js
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import sendgridEmail from '@sendgrid/mail';
 import mjml2html from "mjml";
+import { RequestStatusEnum } from "../../types/dbTablesEnums";
 
 const TUPU_EMAIL = 'mentors@tupu.io'; // used for tupu add team recipient
 
@@ -10,7 +11,7 @@ if (process.env.SENDGRID_API_KEY) {
 }
 
 
-function sendEmail({recipient, subject, htmlBody, textBody}) {
+function sendEmail({ recipient, subject, htmlBody, textBody, replyTo }) {
   if (!process.env.SENDGRID_API_KEY) {
     console.error('SendGrid error: SENDGRID_API_KEY is not set');
     return;
@@ -22,13 +23,16 @@ function sendEmail({recipient, subject, htmlBody, textBody}) {
   const from = process.env.SENDGRID_EMAIL_VERIFIED_SENDER;
   recipient = process.env.DEV_EMAIL_RECIPIENT || recipient;
   subject = buildSubjectLine(subject);
-  const msg = {
+  let msg = {
     to: recipient,
     from, 
     subject,
     text: textBody,
     html: htmlBody,
   };
+  if (replyTo) {
+    msg = { replyTo, ...msg };
+  }
   sendgridEmail
     .send(msg)
     .then(() => {
@@ -36,6 +40,7 @@ function sendEmail({recipient, subject, htmlBody, textBody}) {
     })
     .catch((error) => {
       console.error('SendGrid error:', error)
+      console.error('SendGrid error:', error.response.body);
       console.error(`Could not deliver email to <${recipient}>,\n subject "${subject}"`);
     });
 }
@@ -84,37 +89,156 @@ export const sendPreferencesUpdatedEmail = (recipient, firstName) => {
   
   const preferencesUpdatedEmailTxt = loadTXTTemplate(templateName)
     .replace(/\[\[firstName\]\]/g, firstName);
-  sendNotificationEmail(recipient, subject, emailTitle, preferencesUpdatedEmailTxt);  
+  sendNotificationEmail(recipient, subject, preferencesUpdatedEmailTxt);  
 }
 
-const sendNotificationEmail = (recipient, subject, emailTitle, emailTxt) => {
-  const emailHTML = createNotificationHTMLEmail(emailTitle, emailTxt);
+const sendNotificationEmail = (recipient, subject, emailTxt, replyTo) => {
+  const emailHTML = createNotificationHTMLEmail(subject, emailTxt);
   const msg = { 
     recipient: recipient,
     subject: subject,
     htmlBody: emailHTML,
     textBody: emailTxt,
+    replyTo
   };
   sendEmail(msg);
+}
+
+const sendNotificationEmailToUsers = ({
+  mentee, 
+  mentor,
+  templateName,
+  subject,
+  fillInFieldsFn,
+  replyTo
+}) => {
+  const recipients = [["mentee", mentee.email], ["mentor", mentor.email], ["tupu", TUPU_EMAIL]];
+  for (const recipient of recipients) {
+    const [userType, userEmail] = recipient;
+    console.log("writing to", userEmail, "as", userType);
+    const emailTxt = fillInFieldsFn(loadTXTTemplate(`${templateName}-${userType}`))
+    sendNotificationEmail(userEmail, subject, emailTxt, replyTo);
+  }  
+}
+
+const buildLongOrShortTermLabel = (longTerm) => (longTerm ? "long":"short") + " term";
+
+const buildReasonString = (requestStatus) => {
+  switch(requestStatus) {
+    case RequestStatusEnum.Rejected:
+      return "While we do not know the reason, we're sure it's nothing personal.";
+    case RequestStatusEnum.RejectedBusy:
+      return "This period might be not the right one.";
+    case RequestStatusEnum.RejectedNoGoodFit:
+    default:
+      return "There could be another mentor that might be a better fit.";
+  }
+};
+
+export const sendMenteeMentorshipClosedEmail = ({ mentee, mentor, menteeFeedback, tupuFeedback, }) => {
+  // mentee and mentor = { name: "", email: "" }
+  const params = {
+    mentee, 
+    mentor,
+    templateName: 'mentee-mentorship-closed-email',
+    subject: "Mentorship closed",
+    fillInFieldsFn: (txtTemplate) => {
+      return txtTemplate
+        .replace(/\[\[menteeName\]\]/g, mentee.name)
+        .replace(/\[\[mentorName\]\]/g, mentor.name)
+        .replace(/\[\[menteeFeedback\]\]/g, menteeFeedback)
+        .replace(/\[\[tupuFeedback\]\]/g, tupuFeedback);
+    }
+  };
+  sendNotificationEmailToUsers(params);
+}
+
+export const sendMentorContactMenteeEmail = ({ mentee, mentor, mentorMessage }) => {
+  // mentee and mentor = { name: "", email: "" }
+  const params = {
+    mentee, 
+    mentor,
+    templateName: 'mentor-contact-mentee-email',
+    subject: "New message from a mentor",
+    replyTo: mentor.email,
+    fillInFieldsFn: (txtTemplate) => {
+      return txtTemplate
+        .replace(/\[\[menteeName\]\]/g, mentee.name)
+        .replace(/\[\[mentorName\]\]/g, mentor.name)
+        .replace(/\[\[mentorMessage\]\]/g, mentorMessage);
+    }
+  };
+  sendNotificationEmailToUsers(params);
+}
+
+export const sendMentorMentorshipClosedEmail = ({ mentee, mentor, mentorFeedback, tupuFeedback, }) => {
+  // mentee and mentor = { name: "", email: "" }
+  const params = {
+    mentee, 
+    mentor,
+    templateName: 'mentor-mentorship-closed-email',
+    subject: "Mentorship closed",
+    fillInFieldsFn: (txtTemplate) => {
+      return txtTemplate
+        .replace(/\[\[menteeName\]\]/g, mentee.name)
+        .replace(/\[\[mentorName\]\]/g, mentor.name)
+        .replace(/\[\[mentorFeedback\]\]/g, mentorFeedback)
+        .replace(/\[\[tupuFeedback\]\]/g, tupuFeedback);
+    }
+  };
+  sendNotificationEmailToUsers(params);
+}
+
+export const sendMentorshipRequestAcceptedEmail = ({ mentee, mentor, longTerm }) => {
+  // mentee and mentor = { name: "", email: "" }
+  const params = {
+    mentee, 
+    mentor,
+    templateName: 'mentorship-request-accepted-email',
+    subject: "Mentorship accepted!",
+    fillInFieldsFn: (txtTemplate) => {
+      return txtTemplate
+        .replace(/\[\[menteeName\]\]/g, mentee.name)
+        .replace(/\[\[mentorName\]\]/g, mentor.name)
+        .replace(/\[\[longOrShortTerm\]\]/g, buildLongOrShortTermLabel(longTerm));
+    }
+  };
+  sendNotificationEmailToUsers(params);
+}
+
+export const sendMentorshipRequestRejectedEmail = ({ mentee, mentor, longTerm, requestStatus }) => {
+  // mentee and mentor = { name: "", email: "" }
+  const params = {
+    mentee, 
+    mentor,
+    templateName: 'mentorship-request-rejected-email',
+    subject: "Mentorship rejected :(",
+    fillInFieldsFn: (txtTemplate) => {
+      return txtTemplate
+        .replace(/\[\[menteeName\]\]/g, mentee.name)
+        .replace(/\[\[mentorName\]\]/g, mentor.name)
+        .replace(/\[\[reason\]\]/g, buildReasonString(requestStatus))
+        .replace(/\[\[longOrShortTerm\]\]/g, buildLongOrShortTermLabel(longTerm));
+    }
+  };
+  sendNotificationEmailToUsers(params);
 }
 
 export const sendMentorshipRequestedEmail = (mentorshipRequest) => {
   const { mentee, mentor, messageRequest, longTerm } = mentorshipRequest;
   // mentee and mentor = { name: "", email: "" }
-  const templateName = 'mentorship-requested-email';
-  const emailTitle = "New Mentorship request!";
-  const subject = "New Mentorship request!";
-  const longOrShortTerm = (longTerm ? "long":"short") + " term";
-
-  const users = [["mentee", mentee.email], ["mentor", mentor.email], ["tupu", TUPU_EMAIL]];
-  for (const user of users) {
-    const [userType, userEmail] = user;
-    console.log("writing to", userEmail, "as", userType);
-    const emailTxt = loadTXTTemplate(`${templateName}-${userType}`)
-      .replace(/\[\[menteeFirstName\]\]/g, mentee.name)
-      .replace(/\[\[mentorFirstName\]\]/g, mentor.name)
-      .replace(/\[\[menteeMessageRequest\]\]/g, messageRequest)
-      .replace(/\[\[longOrShortTerm\]\]/g, longOrShortTerm);
-    sendNotificationEmail(userEmail, subject, emailTitle, emailTxt);
-  }
+  const params = {
+    mentee, 
+    mentor,
+    templateName: 'mentorship-requested-email',
+    subject: "New Mentorship request!",
+    fillInFieldsFn: (txtTemplate) => {
+      return txtTemplate
+        .replace(/\[\[menteeName\]\]/g, mentee.name)
+        .replace(/\[\[mentorName\]\]/g, mentor.name)
+        .replace(/\[\[menteeMessageRequest\]\]/g, messageRequest)
+        .replace(/\[\[longOrShortTerm\]\]/g, buildLongOrShortTermLabel(longTerm));
+    }    
+  };
+  sendNotificationEmailToUsers(params);
 }

--- a/utils/email/templates/mentee-mentorship-closed-email-mentee.txt
+++ b/utils/email/templates/mentee-mentorship-closed-email-mentee.txt
@@ -1,0 +1,24 @@
+Hi [[menteeName]],
+
+You've decided to close the mentorship with the mentor [[mentorName]].
+
+Hopefully you've anticipated the reason during a conversation or by a message.
+
+This is the feedback you left for [[mentorName]]:
+
+---
+
+[[menteeFeedback]]
+
+---
+
+This is the feedback you left for the Tupu App Team:
+
+---
+
+[[tupuFeedback]]
+
+---
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentee-mentorship-closed-email-mentor.txt
+++ b/utils/email/templates/mentee-mentorship-closed-email-mentor.txt
@@ -1,0 +1,16 @@
+Hi [[mentorName]],
+
+The mentee [[menteeName]] decided to close the mentorship with you.
+
+The reasons might be several, hopefully anticipated during a conversation or by a message.
+
+This is their feedback for you:
+
+---
+
+[[menteeFeedback]]
+
+---
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentee-mentorship-closed-email-tupu.txt
+++ b/utils/email/templates/mentee-mentorship-closed-email-tupu.txt
@@ -1,0 +1,22 @@
+Hi Tupu App Team,
+
+The mentee [[menteeName]] decided to close the mentorship with the mentor [[mentorName]].
+
+This is their feedback for the mentor:
+
+---
+
+[[menteeFeedback]]
+
+---
+
+This is their feedback for the Tupu App Team:
+
+---
+
+[[tupuFeedback]]
+
+---
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentor-contact-mentee-email-mentee.txt
+++ b/utils/email/templates/mentor-contact-mentee-email-mentee.txt
@@ -1,0 +1,16 @@
+Hi [[menteeName]]!
+
+You've previously sent a mentorship request to [[mentorName]].
+
+They decided to contact you first, and wrote you this message:
+
+---
+
+[[mentorMessage]]
+
+---
+
+You can contact [[mentorName]] by replying directly to this email!
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentor-contact-mentee-email-mentor.txt
+++ b/utils/email/templates/mentor-contact-mentee-email-mentor.txt
@@ -1,0 +1,14 @@
+Hi [[mentorName]]!
+
+You have sent this message to [[menteeName]]:
+
+---
+
+[[mentorMessage]]
+
+---
+
+[[menteeName]] will reply soon directly to your email.
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentor-contact-mentee-email-tupu.txt
+++ b/utils/email/templates/mentor-contact-mentee-email-tupu.txt
@@ -1,0 +1,16 @@
+Hi Tupu App Team!
+
+The mentor [[mentorName]] sent this message to the mentee [[menteeName]]:
+
+---
+
+[[mentorMessage]]
+
+---
+
+[[menteeName]] will be able to reply directly to [[mentorName]]'s email.
+
+You won't receive further information about their communication.
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentor-mentorship-closed-email-mentee.txt
+++ b/utils/email/templates/mentor-mentorship-closed-email-mentee.txt
@@ -1,0 +1,16 @@
+Hi [[menteeName]],
+
+Your mentor [[mentorName]] decided to close the mentorship with you.
+
+Hopefully this was anticipated during a conversation or by a message.
+
+This is the feedback that [[mentorName]] left for you:
+
+---
+
+[[mentorFeedback]]
+
+---
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentor-mentorship-closed-email-mentor.txt
+++ b/utils/email/templates/mentor-mentorship-closed-email-mentor.txt
@@ -1,0 +1,24 @@
+Hi [[mentorName]],
+
+You've decided to close the mentorship with the mentor [[menteeName]].
+
+Hopefully you've anticipated the reason during a conversation or by a message.
+
+This is the feedback you left for [[menteeName]]:
+
+---
+
+[[mentorFeedback]]
+
+---
+
+This is the feedback you left for the Tupu App Team:
+
+---
+
+[[tupuFeedback]]
+
+---
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentor-mentorship-closed-email-tupu.txt
+++ b/utils/email/templates/mentor-mentorship-closed-email-tupu.txt
@@ -1,0 +1,22 @@
+Hi Tupu App Team,
+
+The mentor [[mentorName]] decided to close the mentorship with the mentee [[menteeName]].
+
+This is their feedback for the mentee:
+
+---
+
+[[mentorFeedback]]
+
+---
+
+This is their feedback for the Tupu App Team:
+
+---
+
+[[tupuFeedback]]
+
+---
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-request-accepted-email-mentee.txt
+++ b/utils/email/templates/mentorship-request-accepted-email-mentee.txt
@@ -1,0 +1,10 @@
+Hi [[menteeName]]!
+
+The mentor [[mentorName]] accepted your request for a [[longOrShortTerm]] mentorship!
+
+This is great news!
+
+Please go to the mentorship details page and book a slot for a call with [[mentorName]] as soon as possible!
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-request-accepted-email-mentor.txt
+++ b/utils/email/templates/mentorship-request-accepted-email-mentor.txt
@@ -1,0 +1,10 @@
+Hi [[mentorName]]!
+
+You have a new mentee!
+
+You have accepted the request of [[menteeName]] for a [[longOrShortTerm]] mentorship!
+
+[[menteeName]] will book a slot for a call soon! Stay tuned!
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-request-accepted-email-tupu.txt
+++ b/utils/email/templates/mentorship-request-accepted-email-tupu.txt
@@ -1,0 +1,10 @@
+Hi Tupu App Team!
+
+The mentor [[mentorName]] accepted the request of the mentee [[menteeName]] for a [[longOrShortTerm]] mentorship!
+
+This is great news!
+
+[[menteeName]] will book a slot for a call with [[mentorName]] as soon as possible.
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-request-cancelled-email-mentee.txt
+++ b/utils/email/templates/mentorship-request-cancelled-email-mentee.txt
@@ -1,0 +1,10 @@
+Hi [[menteeName]],
+
+You changed your mind and cancelled the request for a [[longOrShortTerm]] mentorship with the mentor [[mentorName]].
+
+This is ok, but should not happen often!
+
+Mentors offer their time on a volunteer basis and we'd like to lower their wasted time on the platform.
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-request-cancelled-email-mentor.txt
+++ b/utils/email/templates/mentorship-request-cancelled-email-mentor.txt
@@ -1,0 +1,12 @@
+Hi [[mentorName]],
+
+The mentee [[menteeName]] changed their mind and cancelled the request for a [[longOrShortTerm]] mentorship with you.
+
+This is ok, there might be several reasons for this (e.g. wrong click), please do not take this personally.
+
+We are all here to learn.
+
+This should not happen many time! Keep an eye on these kind of episodes and notify the Tupu App team in case you suspect an abuse of the platform.
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-request-cancelled-email-tupu.txt
+++ b/utils/email/templates/mentorship-request-cancelled-email-tupu.txt
@@ -1,0 +1,8 @@
+Hi Tupu App Team,
+
+The mentee [[menteeName]] cancelled the request for a [[longOrShortTerm]] mentorship with the mentor [[mentorName]].
+
+This is ok, but should not happen many time! Keep an eye on these kind of episodes.
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-request-rejected-email-mentee.txt
+++ b/utils/email/templates/mentorship-request-rejected-email-mentee.txt
@@ -1,0 +1,12 @@
+Hi [[menteeName]],
+
+Unfortunately the mentor [[mentorName]] rejected your request for a [[longOrShortTerm]] mentorship.
+
+This is unfortunate but do not give up!
+
+[[reason]]
+
+Go to the Find a Mentor page and send a request to another mentor that could be a good fit!
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-request-rejected-email-mentor.txt
+++ b/utils/email/templates/mentorship-request-rejected-email-mentor.txt
@@ -1,0 +1,10 @@
+Hi [[mentorName]],
+
+You have decided to not take on a new mentee.
+
+You have rejected the request of [[menteeName]] for a [[longOrShortTerm]] mentorship.
+
+[[reason]]
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-request-rejected-email-tupu.txt
+++ b/utils/email/templates/mentorship-request-rejected-email-tupu.txt
@@ -1,0 +1,10 @@
+Hi Tupu App Team,
+
+It was not a match.
+
+The mentor [[mentorName]] rejected the request of the mentee [[menteeName]] for a [[longOrShortTerm]] mentorship.
+
+[[reason]]
+
+Have a great day,
+Tupu App Team

--- a/utils/email/templates/mentorship-requested-email-mentee.txt
+++ b/utils/email/templates/mentorship-requested-email-mentee.txt
@@ -1,6 +1,6 @@
-Hi [[menteeFirstName]]!
+Hi [[menteeName]]!
 
-We forwarded your request for a [[longOrShortTerm]] mentorship to [[mentorFirstName]].
+We forwarded your request for a [[longOrShortTerm]] mentorship to [[mentorName]].
 
 This is the message you wrote in the request:
 
@@ -10,7 +10,7 @@ This is the message you wrote in the request:
 
 ---
 
-[[mentorFirstName]] will review your application and let you know as soon as possible if this is going to happen or not!
+[[mentorName]] will review your application and let you know as soon as possible if this is going to happen or not!
 
 Have a great day,
 Tupu App Team

--- a/utils/email/templates/mentorship-requested-email-mentor.txt
+++ b/utils/email/templates/mentorship-requested-email-mentor.txt
@@ -1,8 +1,8 @@
-Hi [[mentorFirstName]]!
+Hi [[mentorName]]!
 
-[[menteeFirstName]] has requested you for a [[longOrShortTerm]] mentorship.
+[[menteeName]] has requested you for a [[longOrShortTerm]] mentorship.
 
-This is the message that [[menteeFirstName]] wrote for you in the request:
+This is the message that [[menteeName]] wrote for you in the request:
 
 ---
 
@@ -10,7 +10,7 @@ This is the message that [[menteeFirstName]] wrote for you in the request:
 
 ---
 
-Please, go to your dashboard of the Tupu App, review this application and let [[menteeFirstName]] know as soon as possible if this is going to happen or not!
+Please, go to your dashboard of the Tupu App, review this application and let [[menteeName]] know as soon as possible if this is going to happen or not!
 
 Have a great day,
 Tupu App Team

--- a/utils/email/templates/mentorship-requested-email-tupu.txt
+++ b/utils/email/templates/mentorship-requested-email-tupu.txt
@@ -1,8 +1,8 @@
 Hi Tupu App Team!
 
-The mentee [[menteeFirstName]] requested a [[longOrShortTerm]] mentorship to the mentor [[mentorFirstName]].
+The mentee [[menteeName]] requested a [[longOrShortTerm]] mentorship to the mentor [[mentorName]].
 
-This is the message that the mentee [[menteeFirstName]] wrote in the request:
+This is the message that the mentee [[menteeName]] wrote in the request:
 
 ---
 
@@ -10,7 +10,7 @@ This is the message that the mentee [[menteeFirstName]] wrote in the request:
 
 ---
 
-[[mentorFirstName]] will review the application and let [[menteeFirstName]] know as soon as possible if this is going to happen or not!
+[[mentorName]] will review the application and let [[menteeName]] know as soon as possible if this is going to happen or not!
 
 Have a great day,
 Tupu App Robot


### PR DESCRIPTION
### What Github issue does this PR relate to?

Close #64

Changes proposed in this pull request:

- add TXT templates
- add JS utils functions

### What should the reviewer know?

1. **Free quota with SendGrid is 100emails/day**, each JS func sends 3 emails (mentor, mentee, tupu)
1. uncomment the notification you want to test in `testNotifications`
1. go to `http://localhost:3000/api/testNotifications` to test the notifications (they will all be sent to the recipient specified by `DEV_EMAIL_RECIPIENT` in `.env.local` coming from a sendgrid verified sender specified by `SENDGRID_EMAIL_VERIFIED_SENDER` in `.env.local`, see #50 and its PR #51)

### Quality Assurance(QA) Checklist

<!-- before requesting to merge a PR, ensure that -->

- [x] The app builds and runs properly
