### PR TITLE
BUG #66 Always redirect to home page on role switch

### DIFF
--- a/components/Sidebar/MobileNav.js
+++ b/components/Sidebar/MobileNav.js
@@ -11,11 +11,15 @@ import {
 } from "@chakra-ui/menu";
 import { FiChevronDown, FiMenu } from "react-icons/fi";
 import { signOut } from "next-auth/react";
+import { useRouter } from 'next/router'
 
 const MobileNav = ({ session, onOpen, mode, setMode, ...rest }) => {
   const name = session?.user?.name;
+  const router = useRouter();
+
   const toggleMode = () => {
     setMode(mode === "mentor" ? "mentee" : "mentor");
+    router.push('/');
   };
 
   return (


### PR DESCRIPTION
### What Github issue does this PR relate to?

Close #66 

Changes proposed in this pull request:

Redirect to `'/'` in the toggleMole function.

### What should the reviewer know?

- Not being used to react anymore I am not sure this is the right way, maybe the redirect should happen in a parent component listening to the state ?
-  this PR assume that toggleMode is the only way to switch mode.

### Comments

This will redirect you even if the page exist for the two roles. 

### Quality Assurance(QA) Checklist

- [x] The app builds and runs properly
