### PR TITLE
Updated calendar preference behavior

### DIFF
--- a/components/MentorPreferencesForm/editor.js
+++ b/components/MentorPreferencesForm/editor.js
@@ -8,8 +8,7 @@ import {
 import { Input } from "@chakra-ui/input";
 import { Flex, HStack, VStack } from "@chakra-ui/layout";
 import { useForm } from "react-hook-form";
-import { Switch, Link } from '@chakra-ui/react'
-import { ExternalLinkIcon } from '@chakra-ui/icons'
+import { Switch } from '@chakra-ui/react'
 
 export const MentorPreferencesEditor = ({ profile, setEditMode, mutateProfile }) => {
   const { register, handleSubmit, formState: { errors } } = useForm({
@@ -38,25 +37,24 @@ export const MentorPreferencesEditor = ({ profile, setEditMode, mutateProfile })
       <Flex py={10}>
         <VStack w="full" h="full" p={10} spacing={10} alignItems="flex-start">
           <FormControl isInvalid={errors.mentor?.calendly}>
-            <FormLabel htmlFor="mentor.calendly">Calendly Event Link</FormLabel>
+            <FormLabel htmlFor="mentor.calendly">Calendar Event Link</FormLabel>
             <Input
-              placeholder="https://calendly.com/your_username/your_event_name"
+              placeholder="Calendar link"
               {...register("mentor.calendly", 
-                { required: { value: true, message: "Your Calendly event link is required to be able to start with mentoring."},
+                {
                   pattern: {
                     value: /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i,
                     message: "Invalid URL link."
                   } 
-                })}
+                }
+              )}
               id="mentor.calendly"
             />
             {errors.mentor?.calendly && 
-              <FormErrorMessage>{errors.mentor.calendly.message}</FormErrorMessage>
+              <FormErrorMessage>{errors.mentor?.calendly.message}</FormErrorMessage>
             }            
             <FormHelperText>
-              Your Calendly event link will be used by your mentees to book your mentorship sessions. Pick yours from your <Link href="https://calendly.com/event_types/user/me" isExternal>
-              Calendly events <ExternalLinkIcon mx='2px' />
-              </Link>.
+              Your calendar event link will be used by your mentees to book your mentorship sessions. Pick yours from Calendly, Cal.com, or any other calendar event service.
             </FormHelperText>
           </FormControl>
           <FormControl>

--- a/components/MentorPreferencesForm/viewer.js
+++ b/components/MentorPreferencesForm/viewer.js
@@ -1,5 +1,5 @@
 import { Button } from "@chakra-ui/button";
-import { Flex, Text, VStack } from "@chakra-ui/layout";
+import { Flex, VStack } from "@chakra-ui/layout";
 import { Table, Tbody, Td, Tr } from "@chakra-ui/table";
 import {
   Alert,
@@ -13,7 +13,7 @@ export const MentorPreferencesViewer = ({ profile, setEditMode }) => {
   return (
     <Flex py={10} px={10}>
       <VStack>
-      {!profile.mentor || !profile.mentor.calendly ? (
+      {!profile.mentor ? (
         <Alert status='warning'>
           <AlertIcon />
           You preferences are not filled yet! Please edit your preferences to start with your mentoring journey.
@@ -22,8 +22,17 @@ export const MentorPreferencesViewer = ({ profile, setEditMode }) => {
         <Table variant="simple" size="lg">
           <Tbody>
             <Tr>
-              <Td fontWeight={700}>Calendly Event Link</Td>
-              <Td minWidth={400}>{profile.mentor.calendly}</Td>
+              <Td fontWeight={700}>Calendar Event Link</Td>
+              {profile.mentor.calendly ? (
+                <Td minWidth={400}>{profile.mentor.calendly}</Td>
+              ) : (
+                <Td minWidth={400}>
+                  <Alert status='warning'>
+                    <AlertIcon />
+                    Without a calendar link, your mentees will have to write you an email to set up calls.
+                  </Alert>
+                </Td>
+              )}
             </Tr>
             <Tr>
               <Td fontWeight={700}>Short term mentorships</Td>


### PR DESCRIPTION
<!-- use WIP as prefix in the title if you do not want me to merge this, or set the PR status to Draft! -->

### What Github issue does this PR relate to?

<!-- If this PR will close the issue, use e.g. "Close #6" You could also use "Ref #6" if it's just part of -->

Close #109

Changes proposed in this pull request:

<!-- If this PR is WIP, you could use checkboxes, otherwise a bullet list is fine -->

- There are no required references to Calendly. Instead, user is prompted to input any calendar link if they wish to
- Preferences can now be saved even if the calendar link space is blank
- There is a warning showing the user that calls and meetings will have to be set up through email communication if there is no calendar link

### Quality Assurance(QA) Checklist

<!-- before requesting to merge a PR, ensure that -->

- [ ] The app builds and runs properly
