### PR TITLE
Hide unused preferences

### DIFF
--- a/components/MentorPreferencesForm/editor.js
+++ b/components/MentorPreferencesForm/editor.js
@@ -57,7 +57,7 @@ export const MentorPreferencesEditor = ({ profile, setEditMode, mutateProfile })
               Your calendar event link will be used by your mentees to book your mentorship sessions. Pick yours from Calendly, Cal.com, or any other calendar event service.
             </FormHelperText>
           </FormControl>
-          <FormControl>
+          {/* <FormControl>
             <FormLabel htmlFor="mentor.shortterm">Short term mentorships?</FormLabel>
             <Switch
               {...register("mentor.shortterm")}
@@ -96,7 +96,7 @@ export const MentorPreferencesEditor = ({ profile, setEditMode, mutateProfile })
             <FormHelperText>
             Your profile as mentor will be shown only to logged-in users.
             </FormHelperText>
-          </FormControl>
+          </FormControl> */}
           <FormControl>
             <HStack spacing="24px">
               <Button colorScheme="greenButton" size="md" type="submit">

--- a/components/MentorPreferencesForm/viewer.js
+++ b/components/MentorPreferencesForm/viewer.js
@@ -34,7 +34,7 @@ export const MentorPreferencesViewer = ({ profile, setEditMode }) => {
                 </Td>
               )}
             </Tr>
-            <Tr>
+            {/* <Tr>
               <Td fontWeight={700}>Short term mentorships</Td>
               <Td>{profile.mentor.shortterm ? "Yes" : "No"}</Td>
             </Tr>
@@ -49,7 +49,7 @@ export const MentorPreferencesViewer = ({ profile, setEditMode }) => {
             <Tr>
               <Td fontWeight={700}>Incognito Mode</Td>
               <Td>{profile.mentor.incognito ? "Active" : "Not Active"}</Td>
-            </Tr>
+            </Tr> */}
           </Tbody>
         </Table>
         )}


### PR DESCRIPTION
### What Github issue does this PR relate to?

Close #123

Changes proposed in this pull request:

- I've hidden short/long term mentorship because we do not filter by them anyway and I've realized that we should prevent that both are off so it's ok to hide them.
- I've also hidden the flags about the expiration notification and the incognito mode (as for the moment, only who is logged in can view the mentors).
