### PR TITLE
fix: return null from getUserByEmail when there is no user

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -35,14 +35,18 @@ export default function XataAdapter(client, options = {}) {
       const xata = getXataClient();
       const user = await xata.db.users.filter("email", email).getFirst();
 
-      console.log("getUserByEmail: found user with id", user.id);
+      if (user) {
+        console.log("getUserByEmail: found user with id", user.id);
 
-      return {
-        id: user.id,
-        name: user.name,
-        email: user.email,
-        emailVerified: null,
-      };
+        return {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          emailVerified: null,
+        };
+      }
+
+      return null
     },
 
     async getUserByAccount({ provider, providerAccountId }) {


### PR DESCRIPTION
<!-- use WIP as prefix in the title if you do not want me to merge this, or set the PR status to Draft! -->

### What Github issue does this PR relate to?

#140 

When creating a new user via google social auth, the  `getUserByEmail` method in the Xata auth adapter was erroring because no user object was returned (see below for error)

``` bash
[next-auth][error][adapter_error_getUserByEmail] 
https://next-auth.js.org/errors#adapter_error_getuserbyemail Cannot read property 'id' of null {
  message: "Cannot read property 'id' of null",
  stack: "TypeError: Cannot read property 'id' of null\n" +
    '    at getUserByEmail (webpack-internal:///(api)/./auth/index.js:45:68)\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:96:5)',
  name: 'TypeError'
}
[next-auth][error][OAUTH_CALLBACK_HANDLER_ERROR] 
https://next-auth.js.org/errors#oauth_callback_handler_error Cannot read property 'id' of null TypeError: Cannot read property 'id' of null
    at getUserByEmail (webpack-internal:///(api)/./auth/index.js:45:68)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  name: 'GetUserByEmailError',
  code: undefined
}
```

This PR updates the `getUserByEmail` method in the Xata auth adapter to return null when there is no user

Before is 

<!-- If this PR will close the issue, use e.g. "Close #6" You could also use "Ref #6" if it's just part of -->

Close #

### What should the reviewer know?

<!-- before requesting a review, add some information here -->

### Quality Assurance(QA) Checklist

<!-- before requesting to merge a PR, ensure that -->

- [ ] The app builds and runs properly
